### PR TITLE
Add link to Becoming a teacher design history to footer

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -41,6 +41,9 @@
     {{ govukFooter({
       meta: {
         items: [{
+          text: "Becoming a teacher design history",
+          href: "https://bat-design-history.netlify.app"
+        }, {
           text: "Sitemap",
           href: "/sitemap"
         }]


### PR DESCRIPTION
I have added the corresponding link back to this site from the BAT design history footer.